### PR TITLE
plymouth: add --ignore-serial-consoles to plymouthd cmd parameter

### DIFF
--- a/debian/local/plymouth.init-premount
+++ b/debian/local/plymouth.init-premount
@@ -38,6 +38,6 @@ if [ "${SPLASH}" = "true" ]
 then
 	export PLYMOUTH_FORCE_SCALE
 	mkdir -m 0755 /run/plymouth
-	/usr/sbin/plymouthd --mode=boot --attach-to-session --pid-file=/run/plymouth/pid --kernel-command-line "splash plymouth.ignore-udev"
+	/usr/sbin/plymouthd --mode=boot --attach-to-session --pid-file=/run/plymouth/pid --kernel-command-line "splash plymouth.ignore-udev" --ignore-serial-consoles
 	/usr/bin/plymouth --show-splash
 fi

--- a/systemd-units/plymouth-start.service
+++ b/systemd-units/plymouth-start.service
@@ -9,7 +9,7 @@ ConditionVirtualization=!container
 IgnoreOnIsolate=true
 
 [Service]
-ExecStart=/usr/local/sbin/plymouthd --mode=boot --pid-file=${prefix}/var/run/plymouth/pid --attach-to-session
+ExecStart=/usr/local/sbin/plymouthd --mode=boot --pid-file=${prefix}/var/run/plymouth/pid --attach-to-session --ignore-serial-consoles
 ExecStartPost=-/usr/local/bin/plymouth show-splash
 Type=forking
 RemainAfterExit=yes


### PR DESCRIPTION
on some devices plymouth doesnt work without this option 
so this fixes that also doesnt seem to interfare with currently working devices, tested by @berbascum

I also added it in init-premount but its doesnt get added in initramfs afaik so whats the point of it?

also do I need to add it in other systemd services? others doesnt get used though