### PR TITLE
plymouth-start.service: add --ignore-serial-consoles

### DIFF
--- a/systemd-units/plymouth-start.service.in
+++ b/systemd-units/plymouth-start.service.in
@@ -9,7 +9,7 @@ ConditionVirtualization=!container
 IgnoreOnIsolate=true
 
 [Service]
-ExecStart=@PLYMOUTH_DAEMON_DIR@/plymouthd --mode=boot --pid-file=@plymouthruntimedir@/pid --attach-to-session --kernel-command-line "splash plymouth.ignore-udev"
+ExecStart=@PLYMOUTH_DAEMON_DIR@/plymouthd --mode=boot --pid-file=@plymouthruntimedir@/pid --attach-to-session --kernel-command-line "splash plymouth.ignore-udev" --ignore-serial-consoles
 ExecStartPost=-@PLYMOUTH_CLIENT_DIR@/plymouth show-splash
 Type=forking
 RemainAfterExit=yes


### PR DESCRIPTION
should have been part of https://github.com/droidian/plymouth/commit/85f2b557fd576e779e38ff69577cf7fb6efdbd17